### PR TITLE
Updated docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,9 +53,12 @@ services:
   keycloak:
     image: quay.io/keycloak/keycloak:latest  # listens on port 8080
     environment:
-      - KEYCLOAK_USER=admin
-      - KEYCLOAK_PASSWORD=admin
+      - KEYCLOAK_ADMIN=admin
+      - KEYCLOAK_ADMIN_PASSWORD=admin
       - DB_VENDOR=h2
     networks:
       mynet:
-        ipv4_address: 172.25.0.15        
+        ipv4_address: 172.25.0.15
+    command: 
+      - start-dev
+      - --http-relative-path /auth


### PR DESCRIPTION
Without _start-dev_ got the following output:

```
└─$ docker-compose ps
                  Name                                Command               State                                                           Ports                                                        
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
haproxy-api-monetization-demo_haproxy_1    /docker-entrypoint.sh hapr ...   Up       0.0.0.0:80->80/tcp,:::80->80/tcp, 0.0.0.0:8404->8404/tcp,:::8404->8404/tcp, 0.0.0.0:9999->9999/tcp,:::9999->9999/tcp
haproxy-api-monetization-demo_keycloak_1   /opt/keycloak/bin/kc.sh          Exit 0                                                                                                                       
haproxy-api-monetization-demo_server1_1    docker-entrypoint.sh npm start   Up       8080/tcp                                                                                                            
haproxy-api-monetization-demo_server2_1    docker-entrypoint.sh npm start   Up       8080/tcp                                                                                                            
haproxy-api-monetization-demo_server3_1    docker-entrypoint.sh npm start   Up       8080/tcp 

```
```
└─$ docker logs 2449e01599b7
Keycloak - Open Source Identity and Access Management

Find more information at: https://www.keycloak.org/docs/latest

Usage:

kc.sh [OPTIONS] [COMMAND]

Use this command-line tool to manage your Keycloak cluster.
Make sure the command is available on your "PATH" or prefix it with "./" (e.g.:
"./kc.sh") to execute from the current folder.

Options:

-cf, --config-file <file>
                     Set the path to a configuration file. By default, configuration properties are
                       read from the "keycloak.conf" file in the "conf" directory.
-h, --help           This help message.
-v, --verbose        Print out error details when running this command.
-V, --version        Show version information

Commands:

  build                   Creates a new and optimized server image.
  start                   Start the server.
  start-dev               Start the server in development mode.
  export                  Export data from realms to a file or directory.
  import                  Import data from a directory or a file.
  show-config             Print out the current configuration.
  tools                   Utilities for use and interaction with the server.
    completion            Generate bash/zsh completion script for kc.sh.

Examples:

  Start the server in development mode for local development or testing:

      $ kc.sh start-dev

  Building an optimized server runtime:

      $ kc.sh build <OPTIONS>

  Start the server in production mode:

      $ kc.sh start <OPTIONS>

  Enable auto-completion to bash/zsh:

      $ source <(kc.sh tools completion)

  Please, take a look at the documentation for more details before deploying in
production.

Use "kc.sh start --help" for the available options when starting the server.
Use "kc.sh <command> --help" for more information about other commands.

```

And without _--http-relative-path /auth_ the entry point http://localhost/auth was not available.